### PR TITLE
リーダーボード提出用 Dockerfile の追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.8-slim-buster
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        jq \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install requirements
+RUN pip install --no-cache-dir \
+        "mecab-python3==0.996.5" \
+        "pandas==1.1.4" \
+        "tqdm" \
+        "rank_bm25==0.2.1" \
+        "transformers==2.11.0" \
+        "spacy==2.3.2" \
+        "faiss-cpu==1.6.3" \
+        "tensorboard==2.3.0" \
+        "torch==1.9.1"
+
+# Download transformers models in advance
+ARG TRANSFORMERS_BASE_MODEL_NAME="cl-tohoku/bert-base-japanese-whole-word-masking"
+RUN python -c "from transformers.modeling_bert import BertModel; BertModel.from_pretrained('${TRANSFORMERS_BASE_MODEL_NAME}')"
+RUN python -c "from transformers import BertJapaneseTokenizer; BertJapaneseTokenizer.from_pretrained('${TRANSFORMERS_BASE_MODEL_NAME}')"
+ENV TRANSFORMERS_OFFLINE=1
+
+# Copy files to the image
+WORKDIR /app
+COPY dpr dpr
+COPY model model
+COPY dense_retriever.py .
+COPY train_reader.py .
+COPY submission.sh .

--- a/dpr/data/reader_data.py
+++ b/dpr/data/reader_data.py
@@ -63,10 +63,11 @@ class ReaderSample(object):
         Container to collect all Q&A passages data per singe question
     """
 
-    def __init__(self, question: str, answers: List, positive_passages: List[ReaderPassage] = [],
+    def __init__(self, qid: str, question: str, answers: List, positive_passages: List[ReaderPassage] = [],
                  negative_passages: List[ReaderPassage] = [],
                  passages: List[ReaderPassage] = [],
                  ):
+        self.qid = qid
         self.question = question
         self.answers = answers
         self.positive_passages = positive_passages
@@ -136,6 +137,7 @@ def preprocess_retriever_data(samples: List[Dict], gold_info_file: Optional[str]
         return sample
 
     for sample in samples:
+        qid = sample['qid']
         question = sample['question']
 
         if question in canonical_questions:
@@ -164,10 +166,10 @@ def preprocess_retriever_data(samples: List[Dict], gold_info_file: Optional[str]
             positives_from_gold += 1
 
         if is_train_set:
-            yield ReaderSample(question, sample['answers'], positive_passages=positive_passages,
+            yield ReaderSample(qid, question, sample['answers'], positive_passages=positive_passages,
                                negative_passages=negative_passages)
         else:
-            yield ReaderSample(question, sample['answers'], passages=negative_passages)
+            yield ReaderSample(qid, question, sample['answers'], passages=negative_passages)
 
     logger.info('no positive passages samples: %d', no_positive_passages)
     logger.info('positive passages from gold samples: %d', positives_from_gold)
@@ -195,6 +197,7 @@ def convert_retriever_results(is_train_set: bool, input_file: str, out_file_pref
         samples = json.loads("".join(f.readlines()))
         """ samples[0] : List[dict]
         {
+            'qid': str,
             'question': str,
             'answers': List[str],
             'ctxs': [
@@ -439,4 +442,3 @@ def _preprocess_reader_samples_chunk(samples: List, out_file_prefix: str, gold_p
         logger.info('Serialize %d results to %s', len(results), out_file)
         pickle.dump(results, f)
     return out_file
-

--- a/dpr/utils/data_utils.py
+++ b/dpr/utils/data_utils.py
@@ -63,7 +63,7 @@ def read_data_from_json_files(paths: List[str], upsample_rates: List = None) -> 
 
 
 def read_qas(qa_file):
-    questions, question_answers = [], []
+    qids, questions, question_answers = [], [], []
     assert qa_file.endswith((
         '.csv', '.tsv', '.json', '.jsonl',
         '.csv.gz', '.tsv.gz', '.json.gz', '.jsonl.gz'
@@ -75,15 +75,17 @@ def read_qas(qa_file):
         elif qa_file.endswith(('.jsonl', '.jsonl.gz')):
             for line in fi:
                 line = json.loads(line.strip())
+                qids.append(line['qid'])
                 questions.append(line['question'])
                 question_answers.append(line['answers'])
         elif qa_file.endswith(('.json', '.json.gz')):
             for d in json.load(fi):
+                qids.append(d['qid'])
                 questions.append(d['question'])
                 question_answers.append(d['answers'])
         else:
             logger.warning('Cannot read qa_file')
-    return questions, question_answers
+    return qids, questions, question_answers
 
 def read_ctxs(ctxs_file, return_dict=False):
     rows = dict() if return_dict else []

--- a/dpr/utils/data_utils.py
+++ b/dpr/utils/data_utils.py
@@ -77,12 +77,12 @@ def read_qas(qa_file):
                 line = json.loads(line.strip())
                 qids.append(line['qid'])
                 questions.append(line['question'])
-                question_answers.append(line['answers'])
+                question_answers.append(line.get('answers', []))  # test file does not contain `answers` key
         elif qa_file.endswith(('.json', '.json.gz')):
             for d in json.load(fi):
                 qids.append(d['qid'])
                 questions.append(d['question'])
-                question_answers.append(d['answers'])
+                question_answers.append(d.get('answers', []))  # test file does not contain `answers` key
         else:
             logger.warning('Cannot read qa_file')
     return qids, questions, question_answers

--- a/model/README.md
+++ b/model/README.md
@@ -1,0 +1,20 @@
+このディレクトリは、推論システムの Docker イメージが参照するディレクトリです。
+以下のファイルを規定のファイル名で配置することにより、推論システムの Docker イメージが動作します。
+
+- `biencoder.pt`:
+    - biencoder の訓練済みファイル
+- `reader.pt`:
+    - reader の訓練済みファイル
+- `embedding.pickle`:
+    - 文書エンベッディングファイル
+- `passages.tsv.gz`:
+    - 文書集合
+
+例えば、 [../do_example_run.sh](../do_example_run.sh) の実行結果がある場合は、以下の操作により必要なファイルがコピーされます。
+
+```sh
+$ cp ../outputs/exp1/retriever/dpr_biencoder.59.230.pt biencoder.pt
+$ cp ../outputs/exp1/reader/dpr_reader_best.pt reader.pt
+$ cp ../outputs/exp1/embeddings/emb_dpr_biencoder.59.230.pickle embedding.pickle
+$ cp ../datasets/wiki/jawiki-20210503-paragraphs.tsv.gz passages.tsv.gz
+```

--- a/submission.sh
+++ b/submission.sh
@@ -30,4 +30,4 @@ python train_reader.py \
     --model_file $READER_FILE \
     --prediction_results_dir $READER_OUTPUT_DIR
 echo 'Formatting the prediction.'
-cat $READER_OUTPUT_DIR/test_prediction_results.json|jq '.[]|{question: .question, answer: .predictions[0].prediction.text}' > $OUTPUT_FILE
+cat $READER_OUTPUT_DIR/test_prediction_results.json|jq -c '.[]|{qid: .qid, question: .question, answer: .predictions[0].prediction.text}' > $OUTPUT_FILE

--- a/submission.sh
+++ b/submission.sh
@@ -30,4 +30,4 @@ python train_reader.py \
     --model_file $READER_FILE \
     --prediction_results_dir $READER_OUTPUT_DIR
 echo 'Formatting the prediction.'
-cat $READER_OUTPUT_DIR/test_prediction_results.json|jq -c '.[]|{qid: .qid, question: .question, answer: .predictions[0].prediction.text}' > $OUTPUT_FILE
+cat $READER_OUTPUT_DIR/test_prediction_results.json|jq -c '.[]|{qid: .qid, question: .question, prediction: .predictions[0].prediction.text}' > $OUTPUT_FILE

--- a/submission.sh
+++ b/submission.sh
@@ -28,6 +28,7 @@ mkdir $READER_OUTPUT_DIR
 python train_reader.py \
     --dev_file $RETRIEVER_OUTPUT_FILE \
     --model_file $READER_FILE \
-    --prediction_results_dir $READER_OUTPUT_DIR
+    --prediction_results_dir $READER_OUTPUT_DIR \
+    --no_logging_em
 echo 'Formatting the prediction.'
 cat $READER_OUTPUT_DIR/test_prediction_results.json|jq -c '.[]|{qid: .qid, question: .question, prediction: .predictions[0].prediction.text}' > $OUTPUT_FILE

--- a/submission.sh
+++ b/submission.sh
@@ -29,6 +29,6 @@ python train_reader.py \
     --dev_file $RETRIEVER_OUTPUT_FILE \
     --model_file $READER_FILE \
     --prediction_results_dir $READER_OUTPUT_DIR \
-    --no_logging_em
+    --no_calc_em
 echo 'Formatting the prediction.'
 cat $READER_OUTPUT_DIR/test_prediction_results.json|jq -c '.[]|{qid: .qid, question: .question, prediction: .predictions[0].prediction.text}' > $OUTPUT_FILE

--- a/submission.sh
+++ b/submission.sh
@@ -1,0 +1,33 @@
+# Path to the trained models.
+BIENCODER_FILE='model/biencoder.pt'
+READER_FILE='model/reader.pt'
+EMBEDDING_FILE='model/embedding.pickle'
+PASSAGES_FILE='model/passages.tsv.gz'
+
+RETRIEVER_OUTPUT_FILE='model/retriever_output.json'
+READER_OUTPUT_DIR='model/reader_output'
+
+# Get predictions for all questions in the input.
+INPUT_FILE=$1
+OUTPUT_FILE=$2
+
+# Now run predictions on input file.
+echo 'Retrieving passages.'
+python dense_retriever.py \
+    --model_file $BIENCODER_FILE \
+    --ctx_file $PASSAGES_FILE \
+    --encoded_ctx_file $EMBEDDING_FILE \
+    --qa_file $INPUT_FILE \
+    --out_file $RETRIEVER_OUTPUT_FILE \
+    --n-docs 100 \
+    --validation_workers 32 \
+    --batch_size 64 \
+    --projection_dim 768
+echo 'Reading the retrieved passages.'
+mkdir $READER_OUTPUT_DIR
+python train_reader.py \
+    --dev_file $RETRIEVER_OUTPUT_FILE \
+    --model_file $READER_FILE \
+    --prediction_results_dir $READER_OUTPUT_DIR
+echo 'Formatting the prediction.'
+cat $READER_OUTPUT_DIR/test_prediction_results.json|jq '.[]|{question: .question, answer: .predictions[0].prediction.text}' > $OUTPUT_FILE

--- a/train_reader.py
+++ b/train_reader.py
@@ -54,7 +54,9 @@ console = logging.StreamHandler()
 logger.addHandler(console)
 """
 
-ReaderQuestionPredictions = collections.namedtuple('ReaderQuestionPredictions', ['id', 'predictions', 'gold_answers'])
+ReaderQuestionPredictions = collections.namedtuple(
+    'ReaderQuestionPredictions', ['qid', 'question', 'predictions', 'gold_answers']
+)
 
 class ReaderTrainer(object):
     def __init__(self, args):
@@ -414,7 +416,7 @@ class ReaderTrainer(object):
                     predictions = {passages_per_question: SpanPrediction('', -1, -1, -1, '')}
                 else:
                     predictions = {passages_per_question: nbest[0]}
-            batch_results.append(ReaderQuestionPredictions(sample.question, predictions, sample.answers))
+            batch_results.append(ReaderQuestionPredictions(sample.qid, sample.question, predictions, sample.answers))
         return batch_results
 
     def _calc_loss(self, input: ReaderBatch) -> torch.Tensor:
@@ -500,7 +502,8 @@ class ReaderTrainer(object):
             save_results = []
             for r in prediction_results:
                 save_results.append({
-                    'question': r.id,
+                    'qid': r.qid,
+                    'question': r.question,
                     'gold_answers': r.gold_answers,
                     'predictions': [{
                         'top_k': top_k,


### PR DESCRIPTION
AI王リーダーボード提出用の Docker イメージをビルドするための Dockerfile と推論スクリプトを追加します。

ビルド
- あらかじめ `model/` 以下にモデルファイル等を置いておく（詳しくは `model/README.md` を参照）
```sh
$ docker build -t aio2-dpr-baseline .
```

推論スクリプトのテスト
- `--gpus` オプションは NVIDIA Container Toolkit がインストールされた環境で有効
```sh
$ docker run --gpus 2 --rm -v "/local/path/to/input:/app/input" -v "/local/path/to/output:/app/output" aio2-dpr-baseline bash "submission.sh" "input/aio_01_test.jsonl" "output/predictions.jsonl"
```